### PR TITLE
Add statistics dashboard with pie charts

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Rummy Statistics Dashboard</title>
+<link rel="icon" type="image/png" href="icon-192x192.png">
+<link rel="stylesheet" href="style.css">
+<style>
+body { text-align:center; background-color:#005000; color:#fff; font-family:sans-serif; }
+.scorecards { display:flex; flex-wrap:wrap; justify-content:center; gap:10px; margin-top:20px; }
+.card { background:rgba(255,255,255,0.2); border:1px solid #fff; border-radius:8px; padding:10px 20px; width:150px; }
+.charts { display:flex; flex-wrap:wrap; justify-content:center; gap:40px; margin-top:30px; }
+.chart { text-align:center; }
+.legend div { display:flex; align-items:center; justify-content:center; font-size:14px; }
+.legend span { display:inline-block; width:12px; height:12px; margin-right:6px; }
+</style>
+</head>
+<body>
+<h1>Statistics Dashboard</h1>
+<div id="scorecards" class="scorecards">
+    <div class="card"><h3>Games Played</h3><p id="games-played">0</p></div>
+    <div class="card"><h3>Games Won</h3><p id="games-won">0</p></div>
+    <div class="card"><h3>Games Lost</h3><p id="games-lost">0</p></div>
+    <div class="card"><h3>Rounds Played</h3><p id="rounds-played">0</p></div>
+    <div class="card"><h3>Rounds Won</h3><p id="rounds-won">0</p></div>
+    <div class="card"><h3>Rounds Lost</h3><p id="rounds-lost">0</p></div>
+</div>
+<div class="charts">
+    <div class="chart">
+        <canvas id="gameChart" width="200" height="200"></canvas>
+        <div id="gameChart-legend" class="legend"></div>
+    </div>
+    <div class="chart">
+        <canvas id="roundChart" width="200" height="200"></canvas>
+        <div id="roundChart-legend" class="legend"></div>
+    </div>
+</div>
+<a href="index.html" style="color:#FFD700; display:inline-block; margin-top:30px;">Back to Game</a>
+<script src="dashboard.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,105 @@
+// dashboard.js - renders statistics dashboard with simple pie charts
+
+document.addEventListener('DOMContentLoaded', () => {
+    const stats = calculateStats();
+    updateScorecards(stats);
+    drawCharts(stats);
+});
+
+function calculateStats() {
+    let gamesPlayed = 0,
+        roundsPlayed = 0,
+        gamesWon = 0,
+        roundsWon = 0;
+
+    const rawHistory = localStorage.getItem('rummyGameHistory');
+    if (rawHistory) {
+        try {
+            const history = JSON.parse(rawHistory);
+            history.forEach(game => {
+                gamesPlayed += 1;
+                roundsPlayed += game.round || 0;
+                const wins = Array.isArray(game.wins) ? (game.wins[0] || 0) : 0;
+                roundsWon += wins;
+                if (Array.isArray(game.scores)) {
+                    const lowest = Math.min(...game.scores);
+                    if (game.scores[0] === lowest) {
+                        gamesWon += 1;
+                    }
+                }
+            });
+        } catch (e) {
+            console.error('Failed to parse saved game history', e);
+        }
+    }
+
+    const rawCurrent = localStorage.getItem('rummyScoreHistory');
+    if (rawCurrent) {
+        try {
+            const data = JSON.parse(rawCurrent);
+            gamesPlayed += 1; // current game in progress
+            roundsPlayed += data.round || 0;
+            if (Array.isArray(data.wins)) {
+                roundsWon += data.wins[0] || 0;
+            }
+        } catch (e) {
+            console.error('Failed to parse current game stats', e);
+        }
+    }
+
+    const roundsLost = roundsPlayed - roundsWon;
+    const gamesLost = gamesPlayed - gamesWon;
+    return { gamesPlayed, roundsPlayed, gamesWon, gamesLost, roundsWon, roundsLost };
+}
+
+function updateScorecards(s) {
+    document.getElementById('games-played').textContent = s.gamesPlayed;
+    document.getElementById('games-won').textContent = s.gamesWon;
+    document.getElementById('games-lost').textContent = s.gamesLost;
+    document.getElementById('rounds-played').textContent = s.roundsPlayed;
+    document.getElementById('rounds-won').textContent = s.roundsWon;
+    document.getElementById('rounds-lost').textContent = s.roundsLost;
+}
+
+function drawCharts(stats) {
+    drawPieChart('gameChart', 'gameChart-legend', ['Won', 'Lost'], [stats.gamesWon, stats.gamesLost], ['#4CAF50', '#F44336']);
+    drawPieChart('roundChart', 'roundChart-legend', ['Won', 'Lost'], [stats.roundsWon, stats.roundsLost], ['#2196F3', '#FFC107']);
+}
+
+function drawPieChart(canvasId, legendId, labels, values, colors) {
+    const canvas = document.getElementById(canvasId);
+    const ctx = canvas.getContext('2d');
+    const total = values.reduce((a, b) => a + b, 0);
+    let startAngle = -Math.PI / 2;
+    const radius = Math.min(canvas.width, canvas.height) / 2 - 10;
+
+    for (let i = 0; i < values.length; i++) {
+        const sliceAngle = total ? (2 * Math.PI * values[i]) / total : 0;
+        ctx.beginPath();
+        ctx.moveTo(canvas.width / 2, canvas.height / 2);
+        ctx.arc(canvas.width / 2, canvas.height / 2, radius, startAngle, startAngle + sliceAngle);
+        ctx.closePath();
+        ctx.fillStyle = colors[i];
+        ctx.fill();
+
+        const midAngle = startAngle + sliceAngle / 2;
+        const labelX = canvas.width / 2 + Math.cos(midAngle) * (radius * 0.6);
+        const labelY = canvas.height / 2 + Math.sin(midAngle) * (radius * 0.6);
+        const percent = total ? Math.round((values[i] / total) * 100) : 0;
+        ctx.fillStyle = '#000';
+        ctx.font = 'bold 14px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(percent + '%', labelX, labelY);
+
+        startAngle += sliceAngle;
+    }
+
+    const legend = document.getElementById(legendId);
+    legend.innerHTML = '';
+    labels.forEach((label, i) => {
+        const item = document.createElement('div');
+        item.innerHTML = `<span style="background:${colors[i]};"></span>${label}`;
+        legend.appendChild(item);
+    });
+}

--- a/main-v2.js
+++ b/main-v2.js
@@ -56,7 +56,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                 });
             }
-            this.displaySavedStats(true);
         },
 
         loadAssets() {

--- a/ui.js
+++ b/ui.js
@@ -19,7 +19,9 @@ export function initializeUI(App) {
     };
 
     Elements.startGameBtn.addEventListener('click', () => App.startGame());
-    Elements.showStatsBtn.addEventListener('click', () => App.displaySavedStats());
+    Elements.showStatsBtn.addEventListener('click', () => {
+        window.location.href = 'dashboard.html';
+    });
     Elements.nextRoundBtn.addEventListener('click', () => App.handleNextRound());
     Elements.sortButton.addEventListener('click', () => App.handleSort());
     Elements.meldButton.addEventListener('click', () => App.handleMeld());


### PR DESCRIPTION
## Summary
- Add a standalone dashboard page rendering saved game statistics.
- Draw win/loss pie charts with custom canvas code and show scorecards.
- Redirect "Show Statistics" button to the new dashboard and drop auto stats popup on load.

## Testing
- `node --check dashboard.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6193284ac83338b98af5e84a17a78