### PR TITLE
Add Golden Wins and total points to dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -25,6 +25,8 @@ body { text-align:center; background-color:#005000; color:#fff; font-family:sans
     <div class="card"><h3>Rounds Played</h3><p id="rounds-played">0</p></div>
     <div class="card"><h3>Rounds Won</h3><p id="rounds-won">0</p></div>
     <div class="card"><h3>Rounds Lost</h3><p id="rounds-lost">0</p></div>
+    <div class="card"><h3>Golden Wins</h3><p id="golden-wins">0</p></div>
+    <div class="card"><h3>Total Points</h3><p>You: <span id="player-points">0</span><br>Others: <span id="other-points">0</span></p></div>
 </div>
 <div class="charts">
     <div class="chart">

--- a/dashboard.js
+++ b/dashboard.js
@@ -10,7 +10,10 @@ function calculateStats() {
     let gamesPlayed = 0,
         roundsPlayed = 0,
         gamesWon = 0,
-        roundsWon = 0;
+        roundsWon = 0,
+        goldenWins = 0,
+        playerPoints = 0,
+        otherPoints = 0;
 
     const rawHistory = localStorage.getItem('rummyGameHistory');
     if (rawHistory) {
@@ -22,9 +25,15 @@ function calculateStats() {
                 const wins = Array.isArray(game.wins) ? (game.wins[0] || 0) : 0;
                 roundsWon += wins;
                 if (Array.isArray(game.scores)) {
+                    const playerScore = game.scores[0] || 0;
+                    playerPoints += playerScore;
+                    otherPoints += game.scores.slice(1).reduce((a, b) => a + b, 0);
                     const lowest = Math.min(...game.scores);
-                    if (game.scores[0] === lowest) {
+                    if (playerScore === lowest) {
                         gamesWon += 1;
+                        if (playerScore === 0) {
+                            goldenWins += 1;
+                        }
                     }
                 }
             });
@@ -42,6 +51,10 @@ function calculateStats() {
             if (Array.isArray(data.wins)) {
                 roundsWon += data.wins[0] || 0;
             }
+            if (Array.isArray(data.scores)) {
+                playerPoints += data.scores[0] || 0;
+                otherPoints += data.scores.slice(1).reduce((a, b) => a + b, 0);
+            }
         } catch (e) {
             console.error('Failed to parse current game stats', e);
         }
@@ -49,7 +62,7 @@ function calculateStats() {
 
     const roundsLost = roundsPlayed - roundsWon;
     const gamesLost = gamesPlayed - gamesWon;
-    return { gamesPlayed, roundsPlayed, gamesWon, gamesLost, roundsWon, roundsLost };
+    return { gamesPlayed, roundsPlayed, gamesWon, gamesLost, roundsWon, roundsLost, goldenWins, playerPoints, otherPoints };
 }
 
 function updateScorecards(s) {
@@ -59,6 +72,9 @@ function updateScorecards(s) {
     document.getElementById('rounds-played').textContent = s.roundsPlayed;
     document.getElementById('rounds-won').textContent = s.roundsWon;
     document.getElementById('rounds-lost').textContent = s.roundsLost;
+    document.getElementById('golden-wins').textContent = s.goldenWins;
+    document.getElementById('player-points').textContent = s.playerPoints;
+    document.getElementById('other-points').textContent = s.otherPoints;
 }
 
 function drawCharts(stats) {


### PR DESCRIPTION
## Summary
- track golden wins where the player finishes a game with zero points
- display total points for the player and computer opponents
- extend dashboard scorecards with new stats

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/IndianRummy/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c61cf72a708333a6f43cc117231ddd