### PR TITLE
Update post-game options and default settings

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -38,7 +38,10 @@ body { text-align:center; background-color:#005000; color:#fff; font-family:sans
         <div id="roundChart-legend" class="legend"></div>
     </div>
 </div>
-<a href="index.html" style="color:#FFD700; display:inline-block; margin-top:30px;">Back to Game</a>
+<div class="dashboard-actions">
+    <button id="dashboard-home-btn">Back to Home</button>
+    <button id="dashboard-new-game-btn">New Game</button>
+</div>
 <script src="dashboard.js"></script>
 </body>
 </html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -4,6 +4,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const stats = calculateStats();
     updateScorecards(stats);
     drawCharts(stats);
+
+    const homeBtn = document.getElementById('dashboard-home-btn');
+    const newGameBtn = document.getElementById('dashboard-new-game-btn');
+
+    if (homeBtn) {
+        homeBtn.addEventListener('click', () => {
+            localStorage.removeItem('rummyAutoStart');
+            window.location.href = 'index.html';
+        });
+    }
+
+    if (newGameBtn) {
+        newGameBtn.addEventListener('click', () => {
+            localStorage.setItem('rummyAutoStart', 'true');
+            window.location.href = 'index.html';
+        });
+    }
 });
 
 function calculateStats() {

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         </div>
         <div class="setting-item">
             <label for="fast-mode">Fast Mode (No Animations/Sound):</label>
-            <input type="checkbox" id="fast-mode">
+            <input type="checkbox" id="fast-mode" checked>
         </div>
         <a href="how-to-play.html" style="color: #FFD700; margin-top: 15px; display: inline-block;">How to Play</a>
         <br>
@@ -64,8 +64,12 @@
         <h2 id="game-winner-text" style="margin-top:10px;"></h2>
         <h3>Scoreboard</h3>
         <table id="score-table"></table>
-        <button id="next-round-btn">Next Round</button>
-        <button id="close-stats-btn" style="display: none;">Close</button>
+        <div class="scoreboard-actions">
+            <button id="next-round-btn">Next Round</button>
+            <button id="scoreboard-new-game-btn" style="display: none;">New Game</button>
+            <button id="scoreboard-home-btn" style="display: none;">Back to Home</button>
+            <button id="close-stats-btn" style="display: none;">Close</button>
+        </div>
     </div>
     
     <div id="showdown-screen" style="display: none;">

--- a/style.css
+++ b/style.css
@@ -114,7 +114,14 @@ button:hover {
     font-size: 18px;
 }
 
-#next-round-btn, #continue-to-scoreboard-btn {
+.scoreboard-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+}
+
+#next-round-btn, #continue-to-scoreboard-btn, #scoreboard-new-game-btn, #scoreboard-home-btn {
     font-size: 20px;
     padding: 10px 30px;
     margin-top: 20px;
@@ -125,7 +132,7 @@ button:hover {
     cursor: pointer;
     font-weight: bold;
 }
-#next-round-btn:hover, #continue-to-scoreboard-btn:hover {
+#next-round-btn:hover, #continue-to-scoreboard-btn:hover, #scoreboard-new-game-btn:hover, #scoreboard-home-btn:hover {
     background-color: #E03030;
 }
 
@@ -134,6 +141,18 @@ button:disabled {
     color: #c0c0c0;
     cursor: not-allowed;
     border-color: #606060;
+}
+
+.dashboard-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 30px;
+}
+
+.dashboard-actions button {
+    min-width: 160px;
 }
 
 /* Showdown and Learner Mode Styles */

--- a/ui.js
+++ b/ui.js
@@ -11,6 +11,8 @@ export function initializeUI(App) {
         startGameBtn: document.getElementById('start-game-btn'),
         showStatsBtn: document.getElementById('show-stats-btn'),
         nextRoundBtn: document.getElementById('next-round-btn'),
+        scoreboardNewGameBtn: document.getElementById('scoreboard-new-game-btn'),
+        scoreboardHomeBtn: document.getElementById('scoreboard-home-btn'),
         closeStatsBtn: document.getElementById('close-stats-btn'),
         continueToScoreboardBtn: document.getElementById('continue-to-scoreboard-btn'),
         scoreboardScreen: document.getElementById('scoreboard-screen'),
@@ -23,6 +25,8 @@ export function initializeUI(App) {
         window.location.href = 'dashboard.html';
     });
     Elements.nextRoundBtn.addEventListener('click', () => App.handleNextRound());
+    Elements.scoreboardNewGameBtn.addEventListener('click', () => App.handleScoreboardNewGame());
+    Elements.scoreboardHomeBtn.addEventListener('click', () => App.handleScoreboardHome());
     Elements.sortButton.addEventListener('click', () => App.handleSort());
     Elements.meldButton.addEventListener('click', () => App.handleMeld());
     Elements.discardButton.addEventListener('click', () => App.handleDiscard());


### PR DESCRIPTION
## Summary
- persist the most recent settings and support automatically starting a new game with the same configuration
- add dedicated scoreboard actions for starting a new game or returning home after the final round
- default fast mode to enabled and update the statistics dashboard with matching back/home controls

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cfb45486cc83338522c55dce6b5ac9