### PR TITLE
Allow longer matches and add celebration polish

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -19,14 +19,14 @@ body { text-align:center; background-color:#005000; color:#fff; font-family:sans
 <body>
 <h1>Statistics Dashboard</h1>
 <div id="scorecards" class="scorecards">
-    <div class="card"><h3>Games Played</h3><p id="games-played">0</p></div>
-    <div class="card"><h3>Games Won</h3><p id="games-won">0</p></div>
-    <div class="card"><h3>Games Lost</h3><p id="games-lost">0</p></div>
-    <div class="card"><h3>Rounds Played</h3><p id="rounds-played">0</p></div>
-    <div class="card"><h3>Rounds Won</h3><p id="rounds-won">0</p></div>
-    <div class="card"><h3>Rounds Lost</h3><p id="rounds-lost">0</p></div>
-    <div class="card"><h3>Golden Wins</h3><p id="golden-wins">0</p></div>
-    <div class="card"><h3>Total Points</h3><p>You: <span id="player-points">0</span><br>Others: <span id="other-points">0</span></p></div>
+    <div class="card"><h3>🎮 Games Played</h3><p id="games-played">0</p></div>
+    <div class="card"><h3>🏆 Games Won</h3><p id="games-won">0</p></div>
+    <div class="card"><h3>📉 Games Lost</h3><p id="games-lost">0</p></div>
+    <div class="card"><h3>🔄 Rounds Played</h3><p id="rounds-played">0</p></div>
+    <div class="card"><h3>✅ Rounds Won</h3><p id="rounds-won">0</p></div>
+    <div class="card"><h3>❌ Rounds Lost</h3><p id="rounds-lost">0</p></div>
+    <div class="card"><h3>🥇 Golden Wins</h3><p id="golden-wins">0</p></div>
+    <div class="card"><h3>🧮 Total Points</h3><p>You: <span id="player-points">0</span><br>Others: <span id="other-points">0</span></p></div>
 </div>
 <div class="charts">
     <div class="chart">

--- a/index.html
+++ b/index.html
@@ -31,8 +31,25 @@
             <label for="num-rounds">Rounds:</label>
             <select id="num-rounds">
                 <option value="1">1</option>
+                <option value="2">2</option>
                 <option value="3" selected>3</option>
+                <option value="4">4</option>
                 <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+                <option value="9">9</option>
+                <option value="10">10</option>
+                <option value="11">11</option>
+                <option value="12">12</option>
+                <option value="13">13</option>
+                <option value="14">14</option>
+                <option value="15">15</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
             </select>
         </div>
         <div class="setting-item">

--- a/main-v2.js
+++ b/main-v2.js
@@ -292,6 +292,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 clearTimeout(this.messageTimer);
                 this.messageTimer = null;
             }
+            if (this.Elements.scoreboardScreen) {
+                this.Elements.scoreboardScreen.classList.remove('game-complete');
+            }
             this.game = null;
             this.humanPlayer = null;
             this.isAnimating = false;
@@ -800,6 +803,9 @@ document.addEventListener('DOMContentLoaded', () => {
         handleScoreboardNewGame() {
             this.playSound('click');
             this.Elements.scoreboardScreen.style.display = 'none';
+            if (this.Elements.scoreboardScreen) {
+                this.Elements.scoreboardScreen.classList.remove('game-complete');
+            }
             this.finalizeCompletedGame();
             const settings = this.lastSettings ? { ...this.lastSettings } : this.getSettingsFromDom();
             this.startGame(settings);
@@ -808,6 +814,9 @@ document.addEventListener('DOMContentLoaded', () => {
         handleScoreboardHome() {
             this.playSound('click');
             this.Elements.scoreboardScreen.style.display = 'none';
+            if (this.Elements.scoreboardScreen) {
+                this.Elements.scoreboardScreen.classList.remove('game-complete');
+            }
             this.finalizeCompletedGame();
             this.resetStateForNewGame();
             this.Elements.gameContainer.style.display = 'none';
@@ -831,6 +840,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const closeStatsBtn = document.getElementById('close-stats-btn');
             const newGameBtn = this.Elements.scoreboardNewGameBtn;
             const homeBtn = this.Elements.scoreboardHomeBtn;
+            const scoreboardScreen = this.Elements.scoreboardScreen;
             this.Elements.scoreboardScreen.style.display = 'block';
             gameWinnerText.textContent = '';
 
@@ -840,15 +850,18 @@ document.addEventListener('DOMContentLoaded', () => {
             if (homeBtn) homeBtn.style.display = 'none';
 
             const isGameComplete = this.game && this.game.currentRound >= this.game.settings.numRounds;
+            if (scoreboardScreen) {
+                scoreboardScreen.classList.toggle('game-complete', !!isGameComplete);
+            }
 
             if (!initial && this.declarationResult) {
                 if (this.declarationResult.penaltyPlayer) {
                     const message = `${this.declarationResult.penaltyPlayer.name} made a wrong declaration!`;
-                    roundWinnerText.textContent = isGameComplete ? `Game Complete! ${message}` : message;
+                    roundWinnerText.textContent = isGameComplete ? `🎉 Game Complete! ${message}` : message;
                 } else {
                     const message = `${this.declarationResult.winnerName} won Round ${this.game.currentRound}!`;
                     roundWinnerText.textContent = isGameComplete
-                        ? `Game Complete! ${this.declarationResult.winnerName} won the final round.`
+                        ? `🎉 Game Complete! ${this.declarationResult.winnerName} won the final round.`
                         : message;
                     const winnerIndex = this.game.players.findIndex(p => p.name === this.declarationResult.winnerName);
                     if (winnerIndex >= 0) {
@@ -857,7 +870,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 this.saveScoreHistory();
             } else if (isGameComplete) {
-                roundWinnerText.textContent = 'Game Complete! Final standings below.';
+                roundWinnerText.textContent = '🎉 Game Complete! Final standings below.';
             } else {
                 roundWinnerText.textContent = `Current standings after Round ${this.game.currentRound}`;
             }
@@ -878,8 +891,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const winnerName = this.game.players[winnerIndex].name;
                 gameWinnerText.textContent =
                     winnerIndex === 0
-                        ? `Congratulations! You win the game with ${lowest} points!`
-                        : `${winnerName} wins the game with ${lowest} points!`;
+                        ? `🏆 Congratulations! You win the game with ${lowest} points!`
+                        : `🏆 ${winnerName} wins the game with ${lowest} points!`;
                 nextRoundBtn.style.display = 'none';
                 if (newGameBtn) newGameBtn.style.display = 'inline-block';
                 if (homeBtn) homeBtn.style.display = 'inline-block';
@@ -914,6 +927,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (this.Elements.scoreboardHomeBtn) this.Elements.scoreboardHomeBtn.style.display = 'none';
             closeStatsBtn.style.display = 'inline-block';
             gameWinnerText.textContent = '';
+            if (this.Elements.scoreboardScreen) {
+                this.Elements.scoreboardScreen.classList.remove('game-complete');
+            }
 
             // --- Aggregate statistics for the human player only ---
             let gamesPlayed = 0;
@@ -989,6 +1005,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (this.Elements.scoreboardHomeBtn) this.Elements.scoreboardHomeBtn.style.display = 'none';
             this.Elements.settingsScreen.style.display = 'block';
             this.applySettingsToDom(this.lastSettings || this.getSettingsFromDom());
+            if (this.Elements.scoreboardScreen) {
+                this.Elements.scoreboardScreen.classList.remove('game-complete');
+            }
         },
 
 

--- a/style.css
+++ b/style.css
@@ -95,6 +95,8 @@ button:hover {
     color: white;
     width: 80%;
     max-width: 900px;
+    position: relative;
+    overflow: hidden;
 }
 
 #scoreboard-screen h2, #showdown-screen h2 {
@@ -134,6 +136,63 @@ button:hover {
 }
 #next-round-btn:hover, #continue-to-scoreboard-btn:hover, #scoreboard-new-game-btn:hover, #scoreboard-home-btn:hover {
     background-color: #E03030;
+}
+
+#scoreboard-screen.game-complete {
+    animation: scoreboard-celebrate 0.8s ease-out;
+    box-shadow: 0 0 25px rgba(255, 215, 0, 0.7);
+}
+
+#scoreboard-screen.game-complete::before,
+#scoreboard-screen.game-complete::after {
+    content: '';
+    position: absolute;
+    inset: -40px 0 -20px 0;
+    background-image:
+        radial-gradient(circle, rgba(255, 215, 0, 0.85) 0 6px, transparent 7px),
+        radial-gradient(circle, rgba(135, 206, 250, 0.75) 0 5px, transparent 6px),
+        radial-gradient(circle, rgba(255, 99, 132, 0.75) 0 5px, transparent 6px),
+        radial-gradient(circle, rgba(144, 238, 144, 0.75) 0 5px, transparent 6px);
+    background-size: 160px 160px;
+    animation: confetti-fall 2.6s linear infinite;
+    pointer-events: none;
+    opacity: 0.75;
+}
+
+#scoreboard-screen.game-complete::after {
+    animation-delay: 1.3s;
+    background-size: 140px 140px;
+    opacity: 0.5;
+    filter: hue-rotate(60deg);
+}
+
+@keyframes scoreboard-celebrate {
+    0% {
+        transform: scale(0.95);
+        box-shadow: 0 0 0 rgba(255, 215, 0, 0);
+    }
+    60% {
+        transform: scale(1.03);
+        box-shadow: 0 0 35px rgba(255, 215, 0, 0.85);
+    }
+    100% {
+        transform: scale(1);
+        box-shadow: 0 0 18px rgba(255, 215, 0, 0.5);
+    }
+}
+
+@keyframes confetti-fall {
+    0% {
+        transform: translateY(-40px) rotate(0deg);
+        opacity: 0;
+    }
+    15% {
+        opacity: 0.9;
+    }
+    100% {
+        transform: translateY(120px) rotate(1turn);
+        opacity: 0;
+    }
 }
 
 button:disabled {


### PR DESCRIPTION
## Summary
- expand the rounds selector to support up to 20 rounds
- decorate dashboard statistic cards with emojis for quick recognition
- add celebratory messaging and animation when the game ends

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29172e4948333bd8c1b5412c7ab93