### PR TITLE
fix: offline asset loading by ignoring query parameters in cache lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
     <script type="module" src="main-v2.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
-            const swVersion = 'v2';
+            const swVersion = 'v3';
             const basePath = window.location.pathname.split('/').slice(0, -1).join('/') + '/';
             window.addEventListener('load', () => {
                 navigator.serviceWorker.register(`${basePath}sw.js?v=${swVersion}`);

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 const CACHE_NAME = `rummy-game-cache-${CACHE_VERSION}`;
 
 const APP_SHELL = [
@@ -56,11 +56,20 @@ self.addEventListener('fetch', event => {
           caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
           return response;
         })
-        .catch(() => caches.match(request))
+        .catch(() => caches.match(request, { ignoreSearch: true }))
     );
   } else {
     event.respondWith(
-      caches.match(request).then(resp => resp || fetch(request))
+      caches.match(request, { ignoreSearch: true }).then(resp => {
+        return resp || fetch(request).then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          return response;
+        });
+      }).catch(() => {
+        // If both cache and network fail offline, return a matching cache if possible
+        return caches.match(request, { ignoreSearch: true });
+      })
     );
   }
 });


### PR DESCRIPTION
The PWA was failing to load styles and images offline because the `fetch` listener in `sw.js` did not use `ignoreSearch: true` when matching cached assets. This caused cache misses when assets were requested with query strings (e.g. `?v=v3`).
Added `{ ignoreSearch: true }` to `caches.match()` calls to fix offline fallback correctly. Bumped cache versions.